### PR TITLE
fixed checking of systemd unit file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,8 +77,8 @@
     daemon_reload: true
   with_items: '{{ syncthing_packages }}'
   when:
-    - systemd_unit.stat.isfile is defined
-    - systemd_unit.stat.isfile
+    - systemd_unit.stat.isreg is defined
+    - systemd_unit.stat.isreg
   tags:
     - syncthing
     - service


### PR DESCRIPTION
There is no `isfile` in the stat module:
https://docs.ansible.com/ansible/2.9/modules/stat_module.html